### PR TITLE
Update CEP 2004 README.md

### DIFF
--- a/ceps/2004/README.md
+++ b/ceps/2004/README.md
@@ -11,7 +11,7 @@ The aim of this CEP is to standardize how retries are implemented for the variou
 
 There are three response types used in instructional and challenge modules: Selections, Short Answer and Multiple Choice. By default, the retries field is set to zero, which means the user always has an initial attempt, and no more than that. Therefore, the number of total attempts the user has to submit a correct response is 1 + number-of-retries. All three response types must have at least one retry.
 
-Guidelines about the structure and number of answer options are provided in CEP 2036, [Knowledge Checks, Instructional, Amount](ceps/2036/README.md). This may impact the number of retries. Too many retries could guarantee a certainty of a correct response. Therefore, it's important to consider whether the goal is to assess whether the student has acquired the desired knowledge and to score them appropriately, or whether the goal is that they actually do get to a correct response because it is necessary to move forward in the module. The latter circumstance is sometimes the case in challenge modules. The number and nature of Hints is intertwined with retries ([Question Hint Requirements](ceps/2034/README.md)).
+Guidelines about the structure and number of answer options are provided in CEP 2036, [Knowledge Checks, Instructional, Amount](../2036/README.md). This may impact the number of retries. Too many retries could guarantee a certainty of a correct response. Therefore, it's important to consider whether the goal is to assess whether the student has acquired the desired knowledge and to score them appropriately, or whether the goal is that they actually do get to a correct response because it is necessary to move forward in the module. The latter circumstance is sometimes the case in challenge modules. The number and nature of Hints is intertwined with retries ([Question Hint Requirements](../2034/README.md)).
 
 ## Specification
 
@@ -31,4 +31,5 @@ A “Retry” is the number of attempts a participant is allowed after submittin
 
 ## References and Footnotes
 
-* CEP 2036 for [Knowledge Checks, Instructional, Amount](ceps/2036/README.md)
+* CEP 2034: [Question Hint Requirements](../2034/README.md)
+* CEP 2036: [Knowledge Checks, Instructional, Amount](../2036/README.md)


### PR DESCRIPTION
Fixed links. One can either link by relative path (../CEPNUM/READEME.md) or absolute path in the repo (/ceps/CEPNUM/README.md)